### PR TITLE
fix: send MediaBrowser Authorization header for Jellyfin requests

### DIFF
--- a/backend/mediaserver/ej/make_request.go
+++ b/backend/mediaserver/ej/make_request.go
@@ -39,6 +39,9 @@ func makeRequest(ctx context.Context, msConfig config.Config_MediaServer, url st
 
 func AddEJAuthHeaders(msConfig config.Config_MediaServer, headers map[string]string) map[string]string {
 	headers["X-Emby-Token"] = msConfig.ApiToken
+	if strings.EqualFold(msConfig.Type, "Jellyfin") {
+		headers["Authorization"] = fmt.Sprintf("MediaBrowser Token=\"%s\"", msConfig.ApiToken)
+	}
 	headers["Accept"] = "application/json"
 	headers["X-Emby-Client"] = "aura"
 	headers["X-Emby-Device"] = "aura"

--- a/backend/mediaserver/ej/make_request.go
+++ b/backend/mediaserver/ej/make_request.go
@@ -39,8 +39,8 @@ func makeRequest(ctx context.Context, msConfig config.Config_MediaServer, url st
 
 func AddEJAuthHeaders(msConfig config.Config_MediaServer, headers map[string]string) map[string]string {
 	headers["X-Emby-Token"] = msConfig.ApiToken
-	if strings.EqualFold(msConfig.Type, "Jellyfin") {
-		headers["Authorization"] = fmt.Sprintf("MediaBrowser Token=\"%s\"", msConfig.ApiToken)
+	if msConfig.Type == "Jellyfin" {
+		headers["Authorization"] = fmt.Sprintf(`MediaBrowser Token="%s"`, msConfig.ApiToken)
 	}
 	headers["Accept"] = "application/json"
 	headers["X-Emby-Client"] = "aura"

--- a/frontend/public/CHANGELOG.md
+++ b/frontend/public/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [0.9.100] - 2026-04-01
 
+### Added
+
+- Added new Authorization header for Jellyfin media servers. This is to fix an issue where some Jellyfin servers were not accepting the X-Emby-Token header for authentication. Now, if the media server type is set to Jellyfin, it will use the new Authorization header as well. (Thanks to degradedcode for the PR!)
+
 ### Fixed
 
 - Fixed issue where Save Image Locally option was not getting correct Season/Episode number when episode number was greater than 99.


### PR DESCRIPTION
﻿## Summary
Jellyfin can reject requests that only carry the legacy `X-Emby-Token` header. This adds the standard `Authorization: MediaBrowser Token="..."` header alongside it when the configured media server type is `Jellyfin`, matching the auth scheme Jellyfin has documented/accepted since its early 10.x releases. Emby requests are untouched (the header is only added when `Type == "Jellyfin"`, case-insensitive).

## Change
`backend/mediaserver/ej/make_request.go` - `AddEJAuthHeaders` now also sets:
```go
if strings.EqualFold(msConfig.Type, "Jellyfin") {
    headers["Authorization"] = fmt.Sprintf(`MediaBrowser Token="%s"`, msConfig.ApiToken)
}
```

## Testing
- Verified against a live Jellyfin instance previously returning 401 on preflight: after this change, `docker logs` shows the preflight connection and admin-user lookup both succeeding (200).
- Verified against a second, older Jellyfin 10.11.11 instance that sending `X-Emby-Token` alone, `Authorization` alone, and both together each return 200 - confirming this does not regress older Jellyfin versions.
- Emby code path is unchanged (gated on server type), not empirically retested against an Emby instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
